### PR TITLE
Add optional GITHUB_MERGE_BOT_TRUSTED_TEAMS_PERMISSION_SCOPE trusted teams approvals scope configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,11 +40,22 @@ Seeing as these projects did not fulfil our requirements, we decided to create g
 ## Backlog
 
 - [ ] Support updating PRs by merging instead of rebasing
-- [ ] Automatically reapprove PRs that were approved before updating the PR
 
 ## Installation and deployment
 
 github-merge-bot currently uses username and password or personal access token to authenticate with GitHub. A good way to integrate with GitHub is to create a "bot" user that github-merge-bot authenticates as. Then [create a personal access token](https://help.github.com/articles/creating-a-personal-access-token-for-the-command-line/) and specify that as the password for github-merge-bot.
+
+### Settings
+
+All github-merge-bot settings are configurable from the following environmental variables:
+
+Setting | Default | Description
+--- | --- | ---
+GITHUB_MERGE_BOT_OWNER | | The github organisation of the github repository github-merge-bot will integrate with
+GITHUB_MERGE_BOT_REPO | | The github repository github-merge-bot will integrate with
+GITHUB_MERGE_BOT_USERNAME | | The github user username github-merge-bot will integrate using
+GITHUB_MERGE_BOT_PASSWORD | | The github user password github-merge-bot will integrate using
+GITHUB_MERGE_BOT_TRUSTED_TEAMS_PERMISSION_SCOPE | nil | The github teams permission scope (ex. admin, write) whose members approvals will be considered when re-approving pull requests after a rebase operation. By default, any review approvals will be trusted.
 
 ### Docker
 

--- a/project.clj
+++ b/project.clj
@@ -6,6 +6,8 @@
   :dependencies [[org.clojure/clojure "1.9.0"]
                  [irresponsible/tentacles "0.6.2"]
                  [org.clojure/tools.logging "0.4.1"]
+                 [org.clojure/tools.trace "0.7.10"]
+                 [org.clojure/core.match "0.3.0"]
                  [clj-jgit "0.8.10"]]
   :lein-tools-deps/config {:config-files [:install :user :project]}
   :main ^:skip-aot github-merge-bot.core

--- a/src/github_merge_bot/core.clj
+++ b/src/github_merge_bot/core.clj
@@ -1,7 +1,9 @@
 (ns github-merge-bot.core
   (:require [tentacles.pulls :as pulls]
             [tentacles.core :as tentacles]
-            [clj-jgit.porcelain :as git])
+            [clj-jgit.porcelain :as git]
+            [clojure.core.match :refer [match]]
+            [clojure.string :as string])
   (:import (java.util Timer TimerTask)
            (org.eclipse.jgit.transport UsernamePasswordCredentialsProvider RefSpec)
            (org.eclipse.jgit.revwalk RevWalk)
@@ -17,14 +19,38 @@
 (defn github-create-review [owner repo pr-id & [options]]
   (tentacles/api-call :post "repos/%s/%s/pulls/%s/reviews" [owner repo pr-id] options))
 
-(defn approved? [owner repo pull-request]
-  (let [reviews (github-reviews owner repo (:number pull-request))
-        reviews-by-author (vals (group-by #(-> % :user :id) reviews))
-        decisive-reviews (map (fn [reviews]
-                                (->> reviews (map :state) (filter #{"CHANGES_REQUESTED" "APPROVED"}) last))
-                              reviews-by-author)]
-    (and (< 0 (count (filter #{"APPROVED"} decisive-reviews)))
-         (not-any? #{"CHANGES_REQUESTED"} decisive-reviews))))
+(defn github-repo-teams [owner repo & [options]]
+  (tentacles/api-call :get "repos/%s/%s/teams" [owner, repo] options))
+
+(defn github-team-members [owner team-id & [options]]
+  (tentacles/api-call :get "orgs/%s/team/%s/members" [owner team-id] options))
+
+(defn has-value [key value]
+  (fn [m]
+    (= value (m key))))
+
+(defn group-reviews-by-author [reviews]
+  (vals (group-by #(-> % :user :id) reviews)))
+
+(defn is-review-by-any-team-member? [review team-members]
+  (some (has-value :login (get (get review :user) :login)) team-members))
+
+(defn filter-reviews-by-team-member [reviews team-members is-trusted-team-permission-scope-active]
+  (if is-trusted-team-permission-scope-active
+    (filter #(is-review-by-any-team-member? % team-members) reviews)
+    reviews))
+
+(defn approved? [owner repo pull-request trusted-team-permission-scope]
+   (let [repo-owners-teams (filter #(= (get % :permission) trusted-team-permission-scope) (github-repo-teams owner repo))
+         repo-owners-teams-members (flatten (map #(github-team-members owner %) (map :id repo-owners-teams)))
+         reviews (github-reviews owner repo (:number pull-request))
+         reviews-by-team-member (filter-reviews-by-team-member reviews repo-owners-teams-members (not (string/blank? trusted-team-permission-scope)))
+         reviews-by-author (group-reviews-by-author reviews-by-team-member)
+         decisive-reviews (map (fn [reviews]
+                                 (->> reviews (map :state) (filter #{"CHANGES_REQUESTED" "APPROVED"}) last))
+                               reviews-by-author)]
+     (and (< 0 (count (filter #{"APPROVED"} decisive-reviews)))
+          (not-any? #{"CHANGES_REQUESTED"} decisive-reviews))))
 
 (defn has-label? [pull-request]
   (let [labels (set (map :name (:labels pull-request)))]
@@ -60,11 +86,11 @@
       (= (.getName merge-base)
          (.getName master)))))
 
-(defn update-pull-request [owner repo-name pull-request credentials]
+(defn update-pull-request [owner repo-name pull-request credentials trusted-team-permission-scope]
   (println (str "Updating pull request #" (:number pull-request) " by rebasing its head branch on master..."))
   (let [^Git repo (procure-repo owner repo-name)
         head (:sha (:head pull-request))
-        approved (approved? owner repo-name pull-request)]
+        approved (approved? owner repo-name pull-request trusted-team-permission-scope)]
     (git/git-fetch repo "origin")
     (git/git-checkout repo head)
     (let [rebase-result (-> repo .rebase (.setUpstream "origin/master") .call)]
@@ -100,6 +126,7 @@
   (println "Checking pull requests...")
   (let [owner (System/getenv "GITHUB_MERGE_BOT_OWNER")
         repo (System/getenv "GITHUB_MERGE_BOT_REPO")
+        trusted-teams-permission-scope (System/getenv "GITHUB_MERGE_BOT_TRUSTED_TEAMS_PERMISSION_SCOPE")
         credentials {:username (System/getenv "GITHUB_MERGE_BOT_USERNAME")
                      :password (System/getenv "GITHUB_MERGE_BOT_PASSWORD")}]
     (tentacles/with-defaults {:auth (str (:username credentials) ":" (:password credentials))}
@@ -107,7 +134,7 @@
         (if-let [pr (merge-candidate owner repo (pulls/pulls owner repo))]
           (if (head-up-to-date-with-base? owner repo pr)
             (try-merge-pull-request owner repo pr credentials)
-            (update-pull-request owner repo pr credentials))
+            (update-pull-request owner repo pr credentials trusted-teams-permission-scope))
           (println "No pull requests found to merge or update."))))))
 
 (defn -main


### PR DESCRIPTION
When `GITHUB_MERGE_BOT_TRUSTED_TEAMS_PERMISSION_SCOPE` is set to the trusted repository owner teams permission scope (ex. admin, write),
after rebasing, `github-merge-bot` will reapprove only if the pull request
has been approved by a member of the teams with the configured permission scope.