### PR TITLE
Add GITHUB_MERGE_BOT_TRACE_ENABLED which enables live github-merge-bot.core ns tracing

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ GITHUB_MERGE_BOT_REPO | | The github repository github-merge-bot will integrate 
 GITHUB_MERGE_BOT_USERNAME | | The github user username github-merge-bot will integrate using
 GITHUB_MERGE_BOT_PASSWORD | | The github user password github-merge-bot will integrate using
 GITHUB_MERGE_BOT_TRUSTED_TEAMS_PERMISSION_SCOPE | nil | The github teams permission scope (ex. admin, write) whose members approvals will be considered when re-approving pull requests after a rebase operation. By default, any review approvals will be trusted.
+GITHUB_MERGE_BOT_TRACE_ENABLED | nil | When set to "true", enables `github-merge-bot.core` namespace stdout tracing using [clojure.tools.trace](https://github.com/clojure/tools.trace)
 
 ### Docker
 

--- a/project.clj
+++ b/project.clj
@@ -10,6 +10,6 @@
                  [org.clojure/core.match "0.3.0"]
                  [clj-jgit "0.8.10"]]
   :lein-tools-deps/config {:config-files [:install :user :project]}
-  :main ^:skip-aot github-merge-bot.core
+  :main ^:skip-aot github-merge-bot.main
   :target-path "target/%s"
   :profiles {:uberjar {:aot :all}})

--- a/src/github_merge_bot/core.clj
+++ b/src/github_merge_bot/core.clj
@@ -4,8 +4,7 @@
             [clj-jgit.porcelain :as git]
             [clojure.core.match :refer [match]]
             [clojure.string :as string])
-  (:import (java.util Timer TimerTask)
-           (org.eclipse.jgit.transport UsernamePasswordCredentialsProvider RefSpec)
+  (:import (org.eclipse.jgit.transport UsernamePasswordCredentialsProvider RefSpec)
            (org.eclipse.jgit.revwalk RevWalk)
            (org.eclipse.jgit.revwalk.filter RevFilter)
            (org.eclipse.jgit.lib ObjectId)
@@ -142,10 +141,3 @@
             (match [function]
               [nil] (merge-pull-requests owner repo credentials trusted-teams-permission-scope)
               [function] (apply function args))))))
-
-(defn -main
-  [& args]
-  (let [timer-task (proxy [TimerTask] []
-                     (run []
-                       (run-in-env nil)))]
-    (.schedule (Timer.) timer-task 0 30000)))

--- a/src/github_merge_bot/main.clj
+++ b/src/github_merge_bot/main.clj
@@ -1,0 +1,16 @@
+(ns github-merge-bot.main
+    (:require [github-merge-bot.core :refer :all])
+    (:import (java.util Timer TimerTask)))
+
+(require '[clojure.tools.trace :as trace])
+
+(let [trace-enabled (System/getenv "GITHUB_MERGE_BOT_TRACE_ENABLED")]
+  (if (= trace-enabled "true")
+    (trace/trace-ns 'github-merge-bot.core)))
+
+(defn -main
+  [& args]
+  (let [timer-task (proxy [TimerTask] []
+                          (run []
+                               (run-in-env nil)))]
+    (.schedule (Timer.) timer-task 0 30000)))


### PR DESCRIPTION
Tracing uses clojure.tools.trace (https://github.com/clojure/tools.trace)